### PR TITLE
Feature/labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+hacktoberfest:
+  - changed-files:
+    - any-glob-to-any-file: '**'
+
+hack-docs-contrib:
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'
+
+hack-code-contrib:
+- changed-files:
+  - any-glob-to-any-file: ['**/*.ts', '**/*.js', '**/*.html', '**/*.json']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Labeler workflow"
+on: 
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This pull request adds a GitHub Action workflow that automatically applies the `hacktoberfest` label to pull requests when files are modified. Additionally, two more labels are applied based on file types:

hack-docs-contrib for `.md` file changes.
hack-code-contrib for `.ts`, `.js`, `.html`, and `.json` file changes.
The workflow improves the project’s ability to label PRs efficiently during the Hacktoberfest event and categorize contributions by code and documentation changes.
