### PR TITLE
Handle empty input field in QR code generator

### DIFF
--- a/QR Code Generator/index.html
+++ b/QR Code Generator/index.html
@@ -1,50 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fancy QR Code Generator</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-</head>
-<body>
+  </head>
+  <body>
     <div class="container">
-        <h1>QR Generator</h1>
-        <input type="text" id="text" placeholder="Enter URL or text">
-        <button onclick="generateQR()">Generate QR</button>
-        <div id="qrcode" class="hidden"></div>
-        <button onclick="downloadQR()" id="downloadBtn" class="hidden">Download QR</button>
+      <h1>QR Generator</h1>
+      <input type="text" id="text" placeholder="Enter URL or text" />
+      <button onclick="generateQR()">Generate QR</button>
+      <div id="qrcode" class="hidden"></div>
+      <button onclick="downloadQR()" id="downloadBtn" class="hidden">
+        Download QR
+      </button>
     </div>
 
     <script>
-        let qr;
-        function generateQR() {
-            const text = document.getElementById("text").value;
-            if (text) {
-                const qrContainer = document.getElementById("qrcode");
-                qrContainer.innerHTML = ''; // Clear previous QR code
-                qrContainer.classList.remove('hidden');
-                qrContainer.classList.add('fade-in');
-                
-                qr = new QRCode(qrContainer, {
-                    text: text,
-                    width: 200,
-                    height: 200
-                });
-                
-                document.getElementById("downloadBtn").classList.remove('hidden');
-                document.getElementById("downloadBtn").classList.add('fade-in');
-            }
-        }
+      let qr;
+      function generateQR() {
+        const text = document.getElementById("text").value;
+        if (!text) {
+          alert("Input field is empty!");
+          return;
+        } else if (text) {
+          const qrContainer = document.getElementById("qrcode");
+          qrContainer.innerHTML = ""; // Clear previous QR code
+          qrContainer.classList.remove("hidden");
+          qrContainer.classList.add("fade-in");
 
-        function downloadQR() {
-            const canvas = document.querySelector("#qrcode canvas");
-            const image = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-            const link = document.createElement('a');
-            link.download = 'qrcode.png';
-            link.href = image;
-            link.click();
+          qr = new QRCode(qrContainer, {
+            text: text,
+            width: 200,
+            height: 200,
+          });
+
+          document.getElementById("downloadBtn").classList.remove("hidden");
+          document.getElementById("downloadBtn").classList.add("fade-in");
         }
+      }
+
+      function downloadQR() {
+        const canvas = document.querySelector("#qrcode canvas");
+        const image = canvas
+          .toDataURL("image/png")
+          .replace("image/png", "image/octet-stream");
+        const link = document.createElement("a");
+        link.download = "qrcode.png";
+        link.href = image;
+        link.click();
+      }
     </script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Show an alert when the input field is empty in the QR code generator.

This ensures that users are notified if they attempt to generate a QR code without providing input.